### PR TITLE
`Clone your forked repository` section and description are sticked together

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ This is a basic everyday Calculator with following features:
 
 
 # Run Locally
-- Open Git Bash terminal.
-- Change the current working directory to the location where you want the cloned directory.
-- To clone your forked repository, type ```git clone```, and then paste the URL you copied earlier. It will look like this, with your GitHub username instead of ```YOUR-USERNAME```:
+- Clone your forked repository
 
   ```
   git clone https://github.com/YOUR-USERNAME/CALCULATOR-WEBSITE

--- a/README.md
+++ b/README.md
@@ -32,17 +32,15 @@ This is a basic everyday Calculator with following features:
 
 
 # Run Locally
-- From the 'Code' section of your forked repo, copy the URL of your forked repo under HTTPS/ SSH/ Github CLI.
 - Open Git Bash terminal.
 - Change the current working directory to the location where you want the cloned directory.
-- Type ```git clone```, and then paste the URL you copied earlier. It will look like this, with your GitHub username instead of ```YOUR-USERNAME```:
+- To clone your forked repository, type ```git clone```, and then paste the URL you copied earlier. It will look like this, with your GitHub username instead of ```YOUR-USERNAME```:
 
   ```
   git clone https://github.com/YOUR-USERNAME/CALCULATOR-WEBSITE
   ```
-- Press Enter. You local clone is created now.
 
-  
+
 ## 🚀 About Me
 Hii, I am _**Yoshitha Rathnayake**_. This is one of 
 the many websites which I have made.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ This is a basic everyday Calculator with following features:
 
 
 # Run Locally
+- From the 'Code' section of your forked repo, copy the URL of your forked repo under HTTPS/ SSH/ Github CLI.
+- Open Git Bash terminal.
+- Change the current working directory to the location where you want the cloned directory.
+- Type ```git clone```, and then paste the URL you copied earlier. It will look like this, with your GitHub username instead of ```YOUR-USERNAME```:
 
-- Clone your forked repository
   ```
   git clone https://github.com/YOUR-USERNAME/CALCULATOR-WEBSITE
   ```
+- Press Enter. You local clone is created now.
 
   
 ## 🚀 About Me


### PR DESCRIPTION
I have updated the README.md 
More detailed steps have been added in the ```Clone your Forked Repository``` section of the Markdown File.
I have also fixed the bug mentioned in the issue. The title and the description are not stuck together anymore. 